### PR TITLE
convert an integer type to the least float type

### DIFF
--- a/src/card.jl
+++ b/src/card.jl
@@ -96,7 +96,7 @@ const VALUE_FSC  = Regex(
 const VALUE_FSC_2 = Regex(
 	"^ *" *
 	"(?:" *
-	"(?<strg>'(?:[ -~]|''|)*?(?<ampr>&)? *')(?=\$|/| )|" *
+	"(?<strg>'(?:[ -&(-~]|''|)*?(?<ampr>&)? *')(?=\$|/| )|" *
 	"(?<bool>[FT])|" *
 	"(?<numr>" * NUMBER_FSC_STR_2 * ")|" *
 	"(?<cplx>\\( *(?<real>" * NUMBER_FSC_STR_2 * ") *, *(?<imag>" * NUMBER_FSC_STR_2 * ") *\\))|" *
@@ -108,7 +108,7 @@ const VALUE_FSC_2 = Regex(
 
 const HIERARCH_FSC = Regex(
 	"^ *" *
-	"(?<key>[A-Z0-9 ]*?)" *
+	"(?<key>[A-Z0-9 _-]*?)" *
 	" *(?<equal>=) *" *
 	"(?:" *
 	"(?<strg>'(?:[ -~]|''|)*?')(?=\$|/| )|" *
@@ -224,7 +224,7 @@ Value{T}.
 - `upad::Integer=1`: number of spaces after the units string
 - `truncate::Bool=true`: truncate comment at end of card
 """
-struct Card{T <: AbstractCardType}
+struct Card{T <: AbstractCardType}  # make value a parameter
 	key::AbstractString
 	value::ValueType
 	comment::AbstractString
@@ -369,7 +369,7 @@ function is_string(value::ValueType)
 end
 
 function is_fixed_key(key::AbstractString)
-	key in ["BITPIX", "END", "NAXIS", "SIMPLE"] || !isnothing(match(r"NAXIS\d{1,3}", key))
+	key in ("BITPIX", "END", "NAXIS", "SIMPLE") || !isnothing(match(r"NAXIS\d{1,3}", key))
 end
 
 function is_long_string(value::AbstractString, comment::AbstractString,
@@ -417,13 +417,13 @@ function split_card(key::K, value::S, comment::C, kwds) where
 		comlen == 0 ? 1 : div(length(comment), comlen, RoundUp))
 	#  Create arrays of card types, keywords, values, comments, and formatting keywords
 	#  for each card. Ensure ampersand is appended to each value string, except last.
-	types    = vcat([Value{String}], fill(Continue, ncard-1))
-	keys     = vcat([key], fill("CONTINUE", ncard-1))
-	values   = [value[j1:j2] for (j1, j2) in slices(value, vallen, ncard, true)]
-	comments = [comment[j1:j2] for (j1, j2) in slices(comment, comlen, ncard)]
-	formats  = vcat([formatcard(t, v, c; merge(kwds, (; append = true))...) for (t, v, c) in
-	zip(types[1:(ncard-1)], values[1:(ncard-1)], comments[1:(ncard-1)])],
-	[formatcard(types[ncard], values[ncard], comments[ncard]; kwds...)])
+	types    = (Value{String}, fill(Continue, ncard-1)...)
+	keys     = (key, fill("CONTINUE", ncard-1)...)
+	values   = Tuple(value[j1:j2] for (j1, j2) in slices(value, vallen, ncard, true))
+	comments = Tuple(comment[j1:j2] for (j1, j2) in slices(comment, comlen, ncard))
+	formats  = (Tuple(formatcard(t, v, c; merge(kwds, (; append = true))...) for (t, v, c) in
+		zip(types[1:(ncard-1)], values[1:(ncard-1)], comments[1:(ncard-1)]))...,
+		formatcard(types[ncard], values[ncard], comments[ncard]; kwds...))
 
 	zip(types, keys, values, comments, formats)
 end
@@ -434,8 +434,8 @@ end
 Join CONTINUE cards to initial long string card to create a long value and comment card
 """
 function join_cards(cards::AbstractArray{Card})
-	value = join([c.value for c in cards])
-	comment = join([c.comment for c in cards])
+	value = join((c.value for c in cards))
+	comment = join((c.comment for c in cards))
 	cards[1].format.ampr = 0
 	Card(typename(cards[1]), cards[1].key, value, comment, cards[1].format)
 end
@@ -576,7 +576,7 @@ end
 ####  Format Card Image  ####
 
 function Base.show(io::IO, cards::Vector{Card{<:Any}})
-	print(io, join([repr(card) for card in cards], "\n"))
+	print(io, join(Tuple(repr(card) for card in cards), "\n"))
 end
 
 function Base.show(io::IO, card::Card)
@@ -885,7 +885,7 @@ end
 function value_type(valus::RegexMatch)
 	types = (strg = String, bool = Bool, numr = Real, cplx = Complex, miss = Missing)
 	keys  = (:strg, :bool, :numr, :cplx, :miss)
-	basetype([types[k] for k in keys if valus[k] !== nothing][1])
+	basetype(Tuple(types[k] for k in keys if valus[k] !== nothing)[1])
 end
 
 function parse_value_comment(::Type{Value}, image::AbstractString)
@@ -1022,6 +1022,11 @@ function parse_comment!(format::F, values::R, offsets::N) where
 	(units, comment, format)
 end
 
+"""
+	parse_number(real::AbstractString)
+
+Determine the type of a number as a Float32, Float64, or Integer
+"""
 function parse_number(real::AbstractString)
 	if occursin('D', real) || (occursin('E', real) && overflow(real))
 		value = Base.parse(Float64, replace(real, "E" => "e", "D" => "e"))
@@ -1036,6 +1041,24 @@ function parse_number(real::AbstractString)
 			Base.parse(Int64, real)
 		catch _
 			Base.parse(Int128, real)
+		end
+	end
+	value
+end
+
+"""
+	least_float_type(real::Union{Real, Nothing})
+
+Convert an integer the minimum float type of Float32, Float64, and BigFloat.
+"""
+function least_float_type(value::Union{Real, Nothing})
+	if typeof(value) <: Integer
+		if typemin(Int32) <= value <= typemax(Int32)
+			return convert(Float32, value)
+		elseif typemin(Int64) <= value <= typemax(Int64)
+			return convert(Float64, value)
+		else
+			return convert(BigFloat, value)
 		end
 	end
 	value

--- a/src/fitscore.jl
+++ b/src/fitscore.jl
@@ -164,7 +164,7 @@ function Base.get(hdus::Vector{HDU}, names::K, defaults::D)::Vector where
 	values
 end
 
-function Base.findfirst(key::AbstractString, hdus::Vector{HDU})::Union(Integer, Nothing)
+function Base.findfirst(key::AbstractString, hdus::Vector{HDU})::Union{Integer, Nothing}
 	for (j, hdu) in enumerate(hdus)
 		if uppercase(rstrip(hdu.cards[key])) == uppercase(key)
 			return j

--- a/src/hdu/bintable.jl
+++ b/src/hdu/bintable.jl
@@ -188,19 +188,15 @@ function FieldFormat(::Type{Bintable}, mankeys::DataFormat, reskeys::Dict{S, V},
         unit_ = get(reskeys, "TUNIT$j", "")
         disp  = get(reskeys, "TDISP$j", "")
         dims  = eval(Meta.parse(get(reskeys, "TDIM$j", "")))
-        zero_ = get(reskeys, "TZERO$j",
-            type <: Union{Bool, BitVector, String} ? nothing : 0.0f0)
-        scale = get(reskeys, "TSCAL$j",
-            type <: Union{Bool, BitVector, String} ? nothing : 1.0f0)
+        zero_ = least_float_type(get(reskeys, "TZERO$j",
+            type <: Union{Bool, BitVector, String} ? nothing : 0.0f0))
+        scale = least_float_type(get(reskeys, "TSCAL$j",
+            type <: Union{Bool, BitVector, String} ? nothing : 1.0f0))
         null  = get(reskeys, "TNULL$j", nothing)
         dmin  = parse_string(get(reskeys, "TDMIN$j", nothing))
-        dmin  = dmin !== nothing ? float(dmin) : dmin
         dmax  = parse_string(get(reskeys, "TDMAX$j", nothing))
-        dmax  = dmax !== nothing ? float(dmax) : dmax
         lmin  = parse_string(get(reskeys, "TLMIN$j", nothing))
-        lmin  = lmin !== nothing ? float(lmin) : lmin
         lmax  = parse_string(get(reskeys, "TLMAX$j", nothing))
-        lmax  = lmax !== nothing ? float(lmax) : lmax
 
         fields[j] = BinaryField(name, pntr, type, k+1:k+byts, leng, supp,
             unit_, disp, dims, zero_, scale, null, dmin, dmax, lmin, lmax)
@@ -239,19 +235,15 @@ function FieldFormat(::Type{Bintable}, mankey::DataFormat, reskeys::Dict{S, V},
         unit_ = get(reskeys, "TUNIT$j", "")
         disp  = get(reskeys, "TDISP$j", "")
         dims  = eval(Meta.parse(get(reskeys, "TDIM$j", "")))
-        zero_ = get(reskeys, "TZERO$j",
-            type <: Union{Bool, BitVector, String} ? nothing : 0.0f0)
-        scale = get(reskeys, "TSCAL$j",
-            type <: Union{Bool, BitVector, String} ? nothing : 1.0f0)
+        zero_ = least_float_type(get(reskeys, "TZERO$j",
+            type <: Union{Bool, BitVector, String} ? nothing : 0.0f0))
+        scale = least_float_type(get(reskeys, "TSCAL$j",
+            type <: Union{Bool, BitVector, String} ? nothing : 1.0f0))
         null  = get(reskeys, "TNULL$j", nothing)
         dmin  = get(reskeys, "TDMIN$j", nothing)
-        dmin  = dmin !== nothing ? float(dmin) : dmin
         dmax  = get(reskeys, "TDMAX$j", nothing)
-        dmax  = dmax !== nothing ? float(dmax) : dmax
         lmin  = get(reskeys, "TLMIN$j", nothing)
-        lmin  = lmin !== nothing ? float(lmin) : lmin
         lmax  = get(reskeys, "TLMAX$j", nothing)
-        lmax  = lmax !== nothing ? float(lmax) : lmax
 
         fields[j] = BinaryField(name, pntr, type, k+1:k+byts, leng, supp,
             unit_, disp, dims, zero_, scale, null, dmin, dmax, lmin, lmax)
@@ -292,19 +284,15 @@ function FieldFormat(::Type{Bintable}, mankey::DataFormat, reskeys::Dict{S, V},
         unit_ = get(reskeys, "TUNIT$j", "")
         disp  = get(reskeys, "TDISP$j", "")
         dims  = eval(Meta.parse(get(reskeys, "TDIM$j", "")))
-        zero_ = get(reskeys, "TZERO$j",
-            type <: Union{Bool, BitVector, String} ? nothing : 0.0f0)
-        scale = get(reskeys, "TSCAL$j",
-            type <: Union{Bool, BitVector, String} ? nothing : 1.0f0)
+        zero_ = least_float_type(get(reskeys, "TZERO$j",
+            type <: Union{Bool, BitVector, String} ? nothing : 0.0f0))
+        scale = least_float_type(get(reskeys, "TSCAL$j",
+            type <: Union{Bool, BitVector, String} ? nothing : 1.0f0))
         null  = get(reskeys, "TNULL$j", nothing)
         dmin  = get(reskeys, "TDMIN$j", nothing)
-        dmin  = dmin !== nothing ? float(dmin) : dmin
         dmax  = get(reskeys, "TDMAX$j", nothing)
-        dmax  = dmax !== nothing ? float(dmax) : dmax
         lmin  = get(reskeys, "TLMIN$j", nothing)
-        lmin  = lmin !== nothing ? float(lmin) : lmin
         lmax  = get(reskeys, "TLMAX$j", nothing)
-        lmax  = lmax !== nothing ? float(lmax) : lmax
 
         fields[j] = BinaryField(name, pntr, type, k+1:k+byts, leng, supp,
             unit_, disp, dims, zero_, scale, null, dmin, dmax, lmin, lmax)

--- a/src/hdu/image.jl
+++ b/src/hdu/image.jl
@@ -69,13 +69,11 @@ function FieldFormat(::Type{Image}, format::DataFormat, reskeys::Dict{S, V},
     data::Missing) where {S<:AbstractString, V<:ValueType}
 
     #  Get missing value
-    zero_ = get(reskeys, "BZERO", 0.0f0)
-    scale = get(reskeys, "BSCALE", 1.0f0)
+    zero_ = least_float_type(get(reskeys, "BZERO", 0.0f0))
+    scale = least_float_type(get(reskeys, "BSCALE", 1.0f0))
     miss  = format.type in MISSTYPE ? get(reskeys, "BLANK", nothing) : nothing
-    dmin  = get(reskeys, "DATAMIN", nothing)
-    dmin  = dmin !== nothing ? float(dmin) : dmin
-    dmax  = get(reskeys, "DATAMAX", nothing)
-    dmax  = dmax !== nothing ? float(dmax) : dmax
+    dmin  = least_float_type(get(reskeys, "DATAMIN", nothing))
+    dmax  = least_float_type(get(reskeys, "DATAMAX", nothing))
     ImageField(format.type, zero_, scale, miss, dmin, dmax)
 end
 
@@ -96,13 +94,11 @@ function FieldFormat(::Type{Image}, format::DataFormat, reskeys::Dict{S, V},
     data::AbstractArray) where {S<:AbstractString, V<:ValueType}
 
     #  Get missing value
-    zero_ = get(reskeys, "BZERO", 0.0f0)
-    scale = get(reskeys, "BSCALE", 1.0f0)
+    zero_ = least_float_type(get(reskeys, "BZERO", 0.0f0))
+    scale = least_float_type(get(reskeys, "BSCALE", 1.0f0))
     miss  = format.type in MISSTYPE ? get(reskeys, "BLANK", nothing) : nothing
-    dmin  = get(reskeys, "DATAMIN", nothing)
-    dmin  = dmin !== nothing ? float(dmin) : dmin
-    dmax  = get(reskeys, "DATAMAX", nothing)
-    dmax  = dmax !== nothing ? float(dmax) : dmax
+    dmin  = least_float_type(get(reskeys, "DATAMIN", nothing))
+    dmax  = least_float_type(get(reskeys, "DATAMAX", nothing))
     ImageField(format.type, zero_, scale, miss, dmin, dmax)
 end
 

--- a/src/hdu/primary.jl
+++ b/src/hdu/primary.jl
@@ -91,13 +91,11 @@ function FieldFormat(::Type{Primary}, format::DataFormat, reskeys::Dict{S, V},
     data::Missing) where {S<:AbstractString, V<:ValueType}
 
     #  Get missing value
-    zero_ = get(reskeys, "BZERO", 0.0f0)
-    scale = get(reskeys, "BSCALE", 1.0f0)
+    zero_ = least_float_type(get(reskeys, "BZERO", 0.0f0))
+    scale = least_float_type(get(reskeys, "BSCALE", 1.0f0))
     miss  = format.type in MISSTYPE ? get(reskeys, "BLANK", nothing) : nothing
-    dmin  = get(reskeys, "DATAMIN", nothing)
-    dmin  = dmin !== nothing ? float(dmin) : dmin
-    dmax  = get(reskeys, "DATAMAX", nothing)
-    dmax  = dmax !== nothing ? float(dmax) : dmax
+    dmin  = least_float_type(get(reskeys, "DATAMIN", nothing))
+    dmax  = least_float_type(get(reskeys, "DATAMAX", nothing))
     ImageField(format.type, zero_, scale, miss, dmin, dmax)
 end
 
@@ -118,13 +116,11 @@ function FieldFormat(::Type{Primary}, format::DataFormat, reskeys::Dict{S, V},
     data::AbstractArray) where {S<:AbstractString, V<:ValueType}
 
     #  Get missing value
-    zero_ = get(reskeys, "BZERO", 0.0f0)
-    scale = get(reskeys, "BSCALE", 1.0f0)
+    zero_ = least_float_type(get(reskeys,  "BZERO", 0.0f0))
+    scale = least_float_type(get(reskeys, "BSCALE", 1.0f0))
     miss  = format.type in MISSTYPE ? get(reskeys, "BLANK", nothing) : nothing
-    dmin  = get(reskeys, "DATAMIN", nothing)
-    dmin  = dmin !== nothing ? float(dmin) : dmin
-    dmax  = get(reskeys, "DATAMAX", nothing)
-    dmax  = dmax !== nothing ? float(dmax) : dmax
+    dmin  = least_float_type(get(reskeys, "DATAMIN", nothing))
+    dmax  = least_float_type(get(reskeys, "DATAMAX", nothing))
     ImageField(format.type, zero_, scale, miss, dmin, dmax)
 end
 

--- a/src/hdu/random.jl
+++ b/src/hdu/random.jl
@@ -158,8 +158,8 @@ function FieldFormat(::Type{Random}, format::DataFormat, reskeys::Dict{S, V},
         name  = rstrip(get(reskeys, "PTYPE$j", "param$j"))
         index = indices[name] = get!(indices, name, 0) + 1
         leng  = 1
-        scale = get(reskeys, "PSCAL$j", 1.0f0)
-        pzero = get(reskeys, "PZERO$j", 0.0f0)
+    scale = least_float_type(get(reskeys, "PSCAL$j", 1.0f0))
+        pzero = least_float_type(get(reskeys, "PZERO$j", 0.0f0))
         fields[j] = RandomField(name, index, type, k+1:k+bytes, leng, (leng,),
             pzero, scale)
         k += bytes
@@ -167,8 +167,8 @@ function FieldFormat(::Type{Random}, format::DataFormat, reskeys::Dict{S, V},
     name  = "data"
     index = 1
     leng  = prod(format.shape)
-    bzero = get(reskeys,  "BZERO", 0.0f0)
-    scale = get(reskeys, "BSCALE", 1.0f0)
+    bzero = least_float_type(get(reskeys,  "BZERO", 0.0f0))
+    scale = least_float_type(get(reskeys, "BSCALE", 1.0f0))
     fields[end] = RandomField(name, index, type, k+1:k+leng*bytes, leng,
         format.shape, bzero, scale)
     fields
@@ -200,8 +200,8 @@ function FieldFormat(::Type{Random}, format::DataFormat, reskeys::Dict{S, V},
             rstrip(get(reskeys, "PTYPE$j", "param$j"))
         index = indices[name] = get!(indices, name, 0) + 1
         leng = 1
-        pzero = get(reskeys, "PZERO$j", 0.0f0)
-        scale = get(reskeys, "PSCAL$j", 1.0f0)
+        pzero = least_float_type(get(reskeys, "PZERO$j", 0.0f0))
+        scale = least_float_type(get(reskeys, "PSCAL$j", 1.0f0))
         fields[j] = RandomField(name, index, type, k+1:k+bytes, leng, (leng,),
             pzero, scale)
         k += bytes
@@ -209,8 +209,8 @@ function FieldFormat(::Type{Random}, format::DataFormat, reskeys::Dict{S, V},
     name  = typeof(data[1]) <: NamedTuple ? String(keys(data[1])[end]) : "data"
     index = 1
     leng  = prod(format.shape)
-    bzero = get(reskeys,  "BZERO", 0.0f0)
-    scale = get(reskeys, "BSCALE", 1.0f0)
+    bzero = least_float_type(get(reskeys,  "BZERO", 0.0f0))
+    scale = least_float_type(get(reskeys, "BSCALE", 1.0f0))
     fields[end] = RandomField(name, index, type, k+1:k+leng*bytes, leng,
         format.shape, bzero, scale)
     fields
@@ -242,8 +242,8 @@ function FieldFormat(::Type{Random}, format::DataFormat, reskeys::Dict{S, V},
             rstrip(get(reskeys, "PTYPE$j", "param$j"))
         index = indices[name] = get!(indices, name, 0) + 1
         leng  = 1
-        pzero = get(reskeys, "PZERO$j", 0.0f0)
-        scale = get(reskeys, "PSCAL$j", 1.0f0)
+        pzero = least_float_type(get(reskeys, "PZERO$j", 0.0f0))
+        scale = least_float_type(get(reskeys, "PSCAL$j", 1.0f0))
         fields[j] = RandomField(name, index, type, k+1:k+bytes, leng, (leng,),
             pzero, scale)
         k += bytes
@@ -251,8 +251,8 @@ function FieldFormat(::Type{Random}, format::DataFormat, reskeys::Dict{S, V},
     name  = "data"
     index = 1
     leng  = prod(format.shape)
-    bzero = get(reskeys,  "BZERO", 0.0f0)
-    scale = get(reskeys, "BSCALE", 1.0f0)
+    bzero = least_float_type(get(reskeys,  "BZERO", 0.0f0))
+    scale = least_float_type(get(reskeys, "BSCALE", 1.0f0))
     fields[end] = RandomField(name, index, type, k+1:k+leng*bytes, leng,
         format.shape, bzero, scale)
     fields

--- a/src/hdu/table.jl
+++ b/src/hdu/table.jl
@@ -150,17 +150,15 @@ function FieldFormat(::Type{Table}, format::DataFormat, reskeys::Dict{S, V},
         unit  = get(reskeys, "TUNIT$j", "")
         form  = fmt.match
         disp  = get(reskeys, "TDISP$j", "")
-        tzero = get(reskeys, "TZERO$j", type <: String ? nothing : 0.0f0)
-        tscal = get(reskeys, "TSCAL$j", type <: String ? nothing : 1.0f0)
+        tzero = least_float_type(get(reskeys, "TZERO$j",
+            type <: String ? nothing : 0.0f0))
+        tscal = least_float_type(get(reskeys, "TSCAL$j",
+            type <: String ? nothing : 1.0f0))
         null  = get(reskeys, "TNULL$j", nothing)
         dmin  = parse_string(get(reskeys, "TDMIN$j", nothing))
-        dmin  = dmin !== nothing ? float(dmin) : dmin
         dmax  = parse_string(get(reskeys, "TDMAX$j", nothing))
-        dmax  = dmax !== nothing ? float(dmax) : dmax
         lmin  = parse_string(get(reskeys, "TLMIN$j", nothing))
-        lmin  = lmin !== nothing ? float(lmin) : lmin
         lmax  = parse_string(get(reskeys, "TLMAX$j", nothing))
-        lmax  = lmax !== nothing ? float(lmax) : lmax
 
         fields[j] = TableField(name, type, k:k+leng-1, unit, form, disp,
             tzero, tscal, null, dmin, dmax, lmin, lmax)
@@ -201,17 +199,15 @@ function FieldFormat(::Type{Table}, format::DataFormat, reskeys::Dict{S, V},
         unit  = get(reskeys, "TUNIT$j", "")
         form  = fmt.match
         disp  = get(reskeys, "TDISP$j", "")
-        tzero = get(reskeys, "TZERO$j", type <: String ? nothing : 0.0f0)
-        tscal = get(reskeys, "TSCAL$j", type <: String ? nothing : 1.0f0)
+        tzero = least_float_type(get(reskeys, "TZERO$j",
+            type <: String ? nothing : 0.0f0))
+        tscal = least_float_type(get(reskeys, "TSCAL$j",
+            type <: String ? nothing : 1.0f0))
         null  = get(reskeys, "TNULL$j", nothing)
-        dmin  = get(reskeys, "TDMIN$j", nothing)
-        dmin  = dmin !== nothing ? float(dmin) : dmin
-        dmax  = get(reskeys, "TDMAX$j", nothing)
-        dmax  = dmax !== nothing ? float(dmax) : dmax
-        lmin  = get(reskeys, "TLMIN$j", nothing)
-        lmin  = lmin !== nothing ? float(lmin) : lmin
-        lmax  = get(reskeys, "TLMAX$j", nothing)
-        lmax  = lmax !== nothing ? float(lmax) : lmax
+        dmin  = parse_string(get(reskeys, "TDMIN$j", nothing))
+        dmax  = parse_string(get(reskeys, "TDMAX$j", nothing))
+        lmin  = parse_string(get(reskeys, "TLMIN$j", nothing))
+        lmax  = parse_string(get(reskeys, "TLMAX$j", nothing))
 
         fields[j] = TableField(name, type, k:k+leng, unit, form, disp,
             tzero, tscal, null, dmin, dmax, lmin, lmax)
@@ -252,13 +248,15 @@ function FieldFormat(::Type{Table}, format::DataFormat, reskeys::Dict{S, V},
         unit  = get(reskeys, "TUNIT$j", "")
         form  = fmt.match
         disp  = get(reskeys, "TDISP$j", "")
-        tzero = get(reskeys, "TZERO$j", type <: String ? nothing : 0.0f0)
-        tscal = get(reskeys, "TSCAL$j", type <: String ? nothing : 1.0f0)
+        tzero = least_float_type(get(reskeys, "TZERO$j",
+            type <: String ? nothing : 0.0f0))
+        tscal = least_float_type(get(reskeys, "TSCAL$j",
+            type <: String ? nothing : 1.0f0))
         null  = get(reskeys, "TNULL$j", nothing)
-        dmin  = get(reskeys, "TDMIN$j", nothing)
-        dmax  = get(reskeys, "TDMAX$j", nothing)
-        lmin  = get(reskeys, "TLMIN$j", nothing)
-        lmax  = get(reskeys, "TLMAX$j", nothing)
+        dmin  = parse_string(get(reskeys, "TDMIN$j", nothing))
+        dmax  = parse_string(get(reskeys, "TDMAX$j", nothing))
+        lmin  = parse_string(get(reskeys, "TLMIN$j", nothing))
+        lmax  = parse_string(get(reskeys, "TLMAX$j", nothing))
 
         fields[j] = TableField(name, type, k:k+leng, unit, form, disp,
             tzero, tscal, null, dmin, dmax, lmin, lmax)


### PR DESCRIPTION
- convert an integer type to the least float type

- ensure proper matching of string with embedded "'" (single quote)

- allow "_" (underscore) and "-" (dash) in HIERARCH keyword

- change some arrays to tuples to improve performance of cards.jl