### PR TITLE
fix(card): Don't write a units field for undefined values

### DIFF
--- a/src/card.jl
+++ b/src/card.jl
@@ -460,7 +460,8 @@ end
 function formatcard(::Type{Value{V}}, value::V, comment::C; kwds...) where
 {V <: ValueType, C <: AbstractString}
 
-	units = unit(value) === NoUnits ? missing : string(unit(value))
+	#  An undefined value has no units: `unit(missing)` is `missing`, not `NoUnits`.
+	units = ismissing(value) || unit(value) === NoUnits ? missing : string(unit(value))
 	#  Create appropriate CardFormat type
 	format = CardFormat(kwds[:fixed])
 	fmt = string(ustrip(value))

--- a/test/card_tests.jl
+++ b/test/card_tests.jl
@@ -202,6 +202,28 @@
     #  create Value Card and get its type with boolean value
     @test typeof(Card("BOOL", true)) <: Card{Value{Bool}}
 
+    #  create Value card with undefined value
+    @test isequal(showfields(Card("UNDEF", missing)),
+                  ("UNDEF", missing, "",
+                   "UNDEF   =                                                                       "))
+
+    #  create Value card with undefined value and comment. An undefined value has no
+    #  units, so no units field is written.
+    @test isequal(showfields(Card("UNDEF", missing, "a comment")),
+                  ("UNDEF", missing, "a comment",
+                   "UNDEF   =                      / a comment                                      "))
+
+    #  an undefined value card round trips through its image
+    @test isequal(showfields(parse(Card,
+                   "UNDEF   =                      / a comment                                      ")),
+                  ("UNDEF", missing, "a comment",
+                   "UNDEF   =                      / a comment                                      "))
+
+    #  a units string in the comment of an undefined value card is preserved
+    @test isequal(showfields(Card("UNDEF", missing, "[m] a comment")),
+                  ("UNDEF", missing, "[m] a comment",
+                   "UNDEF   =                      / [m] a comment                                  "))
+
     #  create Value card with boolean value, fixed-format
     @test isequal(showfields(Card("BOOL", false)),
                   ("BOOL", false, "",


### PR DESCRIPTION
Hi Paul, I ran into this edge case while integrating FITSFiles.jl with AstroImages.jl. Would it make sense to drop the `[]` that sneaks into the comments section when the field is undefined?

**Before**

```julia-repl
julia> Card("UNDEF", missing, "a comment")
UNDEF   =                      / [] a comment
```

**After**

```julia-repl
julia> Card("UNDEF", missing, "a comment")
UNDEF   =                      / a comment
```

This makes handling empty fields easier downstream