### PR TITLE
fix: fix tdim issue

### DIFF
--- a/src/hdu/bintable.jl
+++ b/src/hdu/bintable.jl
@@ -14,6 +14,7 @@ const BINARYTYPE = Dict(
     ComplexF32 => "C", ComplexF64 => "M")
 
 const POINTERTYPE = Dict("P" => Int32, "Q" => Int64, Int32 => "P", Int64 => "Q")
+const TDIMFMT = r"^\((?<dims>\d+(?:,\d+)*)\)\s*$"
 
 """
     BinaryField(name, pntr, type, slice, leng, supp, unit, disp, dims,
@@ -57,13 +58,8 @@ struct BinaryField <: AbstractField
     lmax::Union{AbstractFloat, Nothing}
 end
 
-function _parse_tdim(value)
-    dim_string = strip(String(value))
-    isempty(dim_string) && return nothing
-
-    dims = eval(Meta.parse(dim_string))
-    dims isa Integer ? (dims,) : dims
-end
+parse_tdim(value) = isempty(value) ? nothing :
+    Tuple(parse.(Int, split(match(TDIMFMT, value)[:dims], ',')))
 
 function Base.read(io::IO, ::Type{Bintable}, format::DataFormat,
     fields::Vector{BinaryField}; record::Bool = false, kwds...)
@@ -195,7 +191,7 @@ function FieldFormat(::Type{Bintable}, mankeys::DataFormat, reskeys::Dict{S, V},
         supp  = form[:a]
         unit_ = get(reskeys, "TUNIT$j", "")
         disp  = get(reskeys, "TDISP$j", "")
-        dims  = _parse_tdim(get(reskeys, "TDIM$j", ""))
+        dims  = parse_tdim(get(reskeys, "TDIM$j", ""))
         zero_ = least_float_type(get(reskeys, "TZERO$j",
             type <: Union{Bool, BitVector, String} ? nothing : 0.0f0))
         scale = least_float_type(get(reskeys, "TSCAL$j",
@@ -242,7 +238,7 @@ function FieldFormat(::Type{Bintable}, mankey::DataFormat, reskeys::Dict{S, V},
         #     get(reskeys, "TUNIT$j", "")
         unit_ = get(reskeys, "TUNIT$j", "")
         disp  = get(reskeys, "TDISP$j", "")
-        dims  = _parse_tdim(get(reskeys, "TDIM$j", ""))
+        dims  = parse_tdim(get(reskeys, "TDIM$j", ""))
         zero_ = least_float_type(get(reskeys, "TZERO$j",
             type <: Union{Bool, BitVector, String} ? nothing : 0.0f0))
         scale = least_float_type(get(reskeys, "TSCAL$j",
@@ -291,7 +287,7 @@ function FieldFormat(::Type{Bintable}, mankey::DataFormat, reskeys::Dict{S, V},
         #     get(reskeys, "TUNIT$j", "")
         unit_ = get(reskeys, "TUNIT$j", "")
         disp  = get(reskeys, "TDISP$j", "")
-        dims  = _parse_tdim(get(reskeys, "TDIM$j", ""))
+        dims  = parse_tdim(get(reskeys, "TDIM$j", ""))
         zero_ = least_float_type(get(reskeys, "TZERO$j",
             type <: Union{Bool, BitVector, String} ? nothing : 0.0f0))
         scale = least_float_type(get(reskeys, "TSCAL$j",

--- a/src/hdu/bintable.jl
+++ b/src/hdu/bintable.jl
@@ -57,6 +57,14 @@ struct BinaryField <: AbstractField
     lmax::Union{AbstractFloat, Nothing}
 end
 
+function _parse_tdim(value)
+    dim_string = strip(String(value))
+    isempty(dim_string) && return nothing
+
+    dims = eval(Meta.parse(dim_string))
+    dims isa Integer ? (dims,) : dims
+end
+
 function Base.read(io::IO, ::Type{Bintable}, format::DataFormat,
     fields::Vector{BinaryField}; record::Bool = false, kwds...)
 
@@ -187,7 +195,7 @@ function FieldFormat(::Type{Bintable}, mankeys::DataFormat, reskeys::Dict{S, V},
         supp  = form[:a]
         unit_ = get(reskeys, "TUNIT$j", "")
         disp  = get(reskeys, "TDISP$j", "")
-        dims  = eval(Meta.parse(get(reskeys, "TDIM$j", "")))
+        dims  = _parse_tdim(get(reskeys, "TDIM$j", ""))
         zero_ = least_float_type(get(reskeys, "TZERO$j",
             type <: Union{Bool, BitVector, String} ? nothing : 0.0f0))
         scale = least_float_type(get(reskeys, "TSCAL$j",
@@ -234,7 +242,7 @@ function FieldFormat(::Type{Bintable}, mankey::DataFormat, reskeys::Dict{S, V},
         #     get(reskeys, "TUNIT$j", "")
         unit_ = get(reskeys, "TUNIT$j", "")
         disp  = get(reskeys, "TDISP$j", "")
-        dims  = eval(Meta.parse(get(reskeys, "TDIM$j", "")))
+        dims  = _parse_tdim(get(reskeys, "TDIM$j", ""))
         zero_ = least_float_type(get(reskeys, "TZERO$j",
             type <: Union{Bool, BitVector, String} ? nothing : 0.0f0))
         scale = least_float_type(get(reskeys, "TSCAL$j",
@@ -283,7 +291,7 @@ function FieldFormat(::Type{Bintable}, mankey::DataFormat, reskeys::Dict{S, V},
         #     get(reskeys, "TUNIT$j", "")
         unit_ = get(reskeys, "TUNIT$j", "")
         disp  = get(reskeys, "TDISP$j", "")
-        dims  = eval(Meta.parse(get(reskeys, "TDIM$j", "")))
+        dims  = _parse_tdim(get(reskeys, "TDIM$j", ""))
         zero_ = least_float_type(get(reskeys, "TZERO$j",
             type <: Union{Bool, BitVector, String} ? nothing : 0.0f0))
         scale = least_float_type(get(reskeys, "TSCAL$j",

--- a/test/bintable_hdu_tests.jl
+++ b/test/bintable_hdu_tests.jl
@@ -919,6 +919,13 @@
     @test (length(hdu.data[1]) == 5 && length(hdu.data) == 3 &&
         all([hdu.data[j][:par4] for j=1:3] .== [1.0, 2.0, 3.0]))
 
+    #  test TDIM parsing
+    @test FITSFiles.parse_tdim("") === nothing
+    @test FITSFiles.parse_tdim("(3)") == (3,)
+    @test FITSFiles.parse_tdim("(5,14)") == (5, 14)
+    @test FITSFiles.parse_tdim("(5,14)    ") == (5, 14)
+    @test_throws MethodError FITSFiles.parse_tdim("(5,x)")
+
     #  test one-dimensional TDIM values
     cards = [Card("XTENSION", "BINTABLE"),
              Card("BITPIX", 8),

--- a/test/bintable_hdu_tests.jl
+++ b/test/bintable_hdu_tests.jl
@@ -919,6 +919,35 @@
     @test (length(hdu.data[1]) == 5 && length(hdu.data) == 3 &&
         all([hdu.data[j][:par4] for j=1:3] .== [1.0, 2.0, 3.0]))
 
+    #  test one-dimensional TDIM values
+    cards = [Card("XTENSION", "BINTABLE"),
+             Card("BITPIX", 8),
+             Card("NAXIS", 2),
+             Card("NAXIS1", 24),
+             Card("NAXIS2", 2),
+             Card("PCOUNT", 0),
+             Card("GCOUNT", 1),
+             Card("TFIELDS", 1),
+             Card("TFORM1", "3D"),
+             Card("TTYPE1", "values"),
+             Card("TDIM1", "(3)")]
+    hdu = HDU(Bintable, missing, cards; record=true)
+
+    @test length(hdu.data) == 2
+    @test hdu.data[1].values == zeros(3)
+
+    cards = Card[Card("TDIM1", "(3)")]
+    records = [(values=[1.0, 2.0, 3.0],),
+               (values=[4.0, 5.0, 6.0],)]
+    hdu = HDU(Bintable, records, cards)
+
+    @test hdu.data == records
+
+    columns = (values=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],)
+    hdu = HDU(Bintable, columns, cards)
+
+    @test hdu.data == columns
+
     rm(temppath)
 
 end


### PR DESCRIPTION
Closes #44

Fix one-dimensional FITS TDIM values such as TDIM=(3). These were parsed as an integer, but BinaryField expects dimensions as a tuple or nothing. The new helper normalizes them to (3,) across all binary-table construction paths and adds tests for the changes.